### PR TITLE
Updates to work with debug toolbar 1.2.1 (current)

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,13 +21,11 @@ Have you found yourself doing this all the time?:
 
 Well, I used to do that a lot. So, I decided to write this simple panel.
 
-The idea is to use just one function `debug` and get lots of information. Here's an example of a [real Django App](https://github.com/santiagobasulto/guide-to-testing-in-django):
-
-    from inspector_panel.panels.inspector import debug
+The idea is to use just one function `dj_debug` and get lots of information. Here's an example of a [real Django App](https://github.com/santiagobasulto/guide-to-testing-in-django):
 
     def index(request):
         latest_poll_list = Poll.published.all().order_by('-pub_date')[:5]
-        debug(latest_poll_list)  # Just add this line
+        dj_debug(latest_poll_list)  # Just add this line
         return render_to_response('polls/index.html', {'latest_poll_list': latest_poll_list})
 
 You get first some information in the Debug Toolbar:
@@ -58,9 +56,18 @@ Add `inspector_panel` to your `INSTALLED_APPS`
         'inspector_panel'
     )
 
+Add this setting variable:
+    
+    DEBUG_INSPECTOR_PANEL_EXTEND_BUILTINS = True
+
+If `DEBUG_INSPECTOR_PANEL_EXTEND_BUILTINS` is set to True, debug inspector panel will add a builtin function called `dj_debug` that you can use without importing anything.
+If you set this to False, you have to import the `debug` function whenever you want to use it as follows:
+
+    from inspector_panel import debug
+
 
 ### Use
-
+#### By Importing It
 Just import the debug function:
 
     from inspector_panel import debug
@@ -79,6 +86,20 @@ and use it to debug whatever you want:
 Optionally you can disable console logging:
 
     debug([1, 2, 3], console=False)
+
+#### Without Importing
+After you set `DEBUG_INSPECTOR_PANEL_EXTEND_BUILTINS` to `True`, you no longer need to import a function
+to use `dj_debug`. You can simply use it whenver you want:
+
+    dj_debug([1, 2, 3])
+    dj_debug(Poll)
+    dj_debug(Poll.objects.all())
+
+    def my_function():
+        print "Hello World"
+
+    dj_debug(my_function)
+
 
 ### Important!
 

--- a/inspector_panel/__init__.py
+++ b/inspector_panel/__init__.py
@@ -3,7 +3,9 @@ from django.conf import settings
 __all__ = ["panels"]
 from inspector_panel.panels.inspector import debug
 
-if settings.DEBUG_INSPECTOR_PANEL_EXTEND_BUILTINS:
+DEBUG_INSPECTOR_PANEL_EXTEND_BUILTINS = getattr(settings, 'DEBUG_INSPECTOR_PANEL_EXTEND_BUILTINS', False)
+
+if DEBUG_INSPECTOR_PANEL_EXTEND_BUILTINS:
     # ensure we're not overriding an existing builtin
     try:
         __builtins__['dj_debug']

--- a/inspector_panel/__init__.py
+++ b/inspector_panel/__init__.py
@@ -1,6 +1,8 @@
 from django.conf import settings
 
 __all__ = ["panels"]
+from inspector_panel.panels.inspector import debug
+
 if settings.DEBUG_INSPECTOR_PANEL_EXTEND_BUILTINS:
     # ensure we're not overriding an existing builtin
     try:
@@ -8,5 +10,4 @@ if settings.DEBUG_INSPECTOR_PANEL_EXTEND_BUILTINS:
 
         raise NameError('dj_debug is already in use as a builtin. Set DEBUG_INSPECTOR_PANEL_EXTEND_BUILTINS setting to False.')
     except KeyError as e:
-        from inspector_panel.panels.inspector import debug
         __builtins__['dj_debug'] = debug

--- a/inspector_panel/__init__.py
+++ b/inspector_panel/__init__.py
@@ -7,6 +7,6 @@ if settings.DEBUG_INSPECTOR_PANEL_EXTEND_BUILTINS:
         __builtins__['dj_debug']
 
         raise NameError('dj_debug is already in use as a builtin. Set DEBUG_INSPECTOR_PANEL_EXTEND_BUILTINS setting to False.')
-    except AttributeError as e:
+    except KeyError as e:
         from inspector_panel.panels.inspector import debug
         __builtins__['dj_debug'] = debug

--- a/inspector_panel/__init__.py
+++ b/inspector_panel/__init__.py
@@ -1,3 +1,12 @@
-__all__ = ["panels"]
+from django.conf import settings
 
-from inspector_panel.panels.inspector import debug
+__all__ = ["panels"]
+if settings.DEBUG_INSPECTOR_PANEL_EXTEND_BUILTINS:
+    # ensure we're not overriding an existing builtin
+    try:
+        __builtins__['dj_debug']
+
+        raise NameError('dj_debug is already in use as a builtin. Set DEBUG_INSPECTOR_PANEL_EXTEND_BUILTINS setting to False.')
+    except AttributeError as e:
+        from inspector_panel.panels.inspector import debug
+        __builtins__['dj_debug'] = debug

--- a/inspector_panel/panels/inspector.py
+++ b/inspector_panel/panels/inspector.py
@@ -21,7 +21,6 @@ class DebugRecord(object):
 
 def log_record(record):
     collector.collect(record)
-    pass
 
 
 def debug_class(the_class, record):
@@ -77,7 +76,7 @@ def debug(value, console=True):
 class InspectorPanel(Panel):
 
     name = 'InspectorPanel'
-    template = 'inspector_panel/panels/inspector.html'
+    template = 'inspector.html'
     has_content = True
 
     def __init__(self, *args, **kwargs):

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ def read(fname):
 
 setup(
     name="inspector_panel",
-    version="0.0.1",
+    version="0.0.2",
     author="Santiago Basulto",
     author_email="santiago.basulto@gmail.com",
     description=("A django-debug-toolbar panel to get more information about "

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ def read(fname):
 
 setup(
     name="inspector_panel",
-    version="0.0.2",
+    version="0.0.3",
     author="Santiago Basulto",
     author_email="santiago.basulto@gmail.com",
     description=("A django-debug-toolbar panel to get more information about "


### PR DESCRIPTION
Hi Santiago,

This project was lagging behind a bit and the debug toolbar debug statements weren't showing up for v1.2.1 of the debug toolbar. I made some updates and now both console and toolbar show proper debug statements
